### PR TITLE
Python 3.10

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.8
+FROM python:3.10
 
 ENV PYTHONUNBUFFERED 1
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,5 @@
+asgiref==3.7.2
 Django>=4.2.1,<4.3
-mysqlclient
+mysqlclient==2.1.1
+sqlparse==0.4.4
+typing_extensions==4.6.3

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,2 @@
-
-Django>=2.2,<3.0
-mysql==0.0.2
-
+Django>=4.2.1,<4.3
+mysqlclient


### PR DESCRIPTION
# Updated version of Python and Django
This Pull Request adds a Python 3.10 containerized version with an updated Django.


## Test after adjustment
1. Created a new project with the command:  
 `docker-compose run web django-admin startproject blog .`
3. Changed project files permissions to my user:group :  
 `sudo chown -R $USER:$USER .`
4. Edited the file "settings.py" of django project with the following lines: 
 ``` python
DATABASES = {
    'default': {
        'ENGINE': 'django.db.backends.mysql',
        'NAME': 'mariadb',
        'USER': 'mariadb',
        'PASSWORD': 'mariadb',
        'HOST': 'db',
        'PORT': 3306,
        'OPTIONS': {
            'init_command': "SET sql_mode='STRICT_TRANS_TABLES', innodb_strict_mode=1",
        },
    }
}
```
5. forced docker to build the container from scratch: 
 `docker-compose up --build`
6. The following output was produced: 
 ``` shell
$ docker-compose up --build
[+] Building 28.6s (12/12) FINISHED                                                                                                                   
 => [internal] load build definition from Dockerfile                                                                                             0.0s
 => => transferring dockerfile: 32B                                                                                                              0.0s
 => [internal] load .dockerignore                                                                                                                0.0s
 => => transferring context: 2B                                                                                                                  0.0s
 => [internal] load metadata for docker.io/library/python:3.10                                                                                   1.1s
 => [1/7] FROM docker.io/library/python:3.10@sha256:0da028d058c56277dc3e5f197bcdc53ffe2dd5c6cd947b48747c8a8d24911be4                             0.0s
 => [internal] load build context                                                                                                                0.0s
 => => transferring context: 137B                                                                                                                0.0s
 => CACHED [2/7] RUN mkdir /requirements                                                                                                         0.0s
 => CACHED [3/7] WORKDIR /requirements                                                                                                           0.0s
 => [4/7] COPY requirements.txt /requirements/                                                                                                   0.1s
 => [5/7] RUN pip install -r requirements.txt                                                                                                   25.3s
 => [6/7] RUN mkdir /code                                                                                                                        0.7s
 => [7/7] WORKDIR /code                                                                                                                          0.1s 
 => exporting to image                                                                                                                           1.1s 
 => => exporting layers                                                                                                                          1.1s 
 => => writing image sha256:96d9d64a7228764405d4998e18674ab0786874725c7089bc4af4a29204e74bef                                                     0.0s 
 => => naming to docker.io/library/docker-django-mariadb-compose-web                                                                             0.0s 
[+] Running 2/2
 ⠿ Container docker-django-mariadb-compose-db-1   Created                                                                                        0.0s
 ⠿ Container docker-django-mariadb-compose-web-1  Recreated                                                                                      0.2s
Attaching to docker-django-mariadb-compose-db-1, docker-django-mariadb-compose-web-1
docker-django-mariadb-compose-db-1   | 2023-06-10 15:53:38+00:00 [Note] [Entrypoint]: Entrypoint script for MariaDB Server 1:10.11.3+maria~ubu2204 started.
docker-django-mariadb-compose-db-1   | 2023-06-10 15:53:38+00:00 [Note] [Entrypoint]: Switching to dedicated user 'mysql'
docker-django-mariadb-compose-db-1   | 2023-06-10 15:53:38+00:00 [Note] [Entrypoint]: Entrypoint script for MariaDB Server 1:10.11.3+maria~ubu2204 started.
docker-django-mariadb-compose-db-1   | 2023-06-10 15:53:38+00:00 [Note] [Entrypoint]: MariaDB upgrade not required
docker-django-mariadb-compose-db-1   | 2023-06-10 15:53:38 0 [Note] Starting MariaDB 10.11.3-MariaDB-1:10.11.3+maria~ubu2204 source revision 0bb31039f54bd6a0dc8f0fc7d40e6b58a51998b0 as process 1
docker-django-mariadb-compose-db-1   | 2023-06-10 15:53:38 0 [Note] InnoDB: Compressed tables use zlib 1.2.11
docker-django-mariadb-compose-db-1   | 2023-06-10 15:53:38 0 [Note] InnoDB: Number of transaction pools: 1
docker-django-mariadb-compose-db-1   | 2023-06-10 15:53:38 0 [Note] InnoDB: Using crc32 + pclmulqdq instructions
docker-django-mariadb-compose-db-1   | 2023-06-10 15:53:38 0 [Note] mariadbd: O_TMPFILE is not supported on /tmp (disabling future attempts)
docker-django-mariadb-compose-db-1   | 2023-06-10 15:53:38 0 [Note] InnoDB: Initializing buffer pool, total size = 128.000MiB, chunk size = 2.000MiB
docker-django-mariadb-compose-db-1   | 2023-06-10 15:53:38 0 [Note] InnoDB: Completed initialization of buffer pool
docker-django-mariadb-compose-db-1   | 2023-06-10 15:53:38 0 [Note] InnoDB: File system buffers for log disabled (block size=512 bytes)
docker-django-mariadb-compose-db-1   | 2023-06-10 15:53:38 0 [Note] InnoDB: 128 rollback segments are active.
docker-django-mariadb-compose-db-1   | 2023-06-10 15:53:38 0 [Note] InnoDB: Setting file './ibtmp1' size to 12.000MiB. Physically writing the file full; Please wait ...
docker-django-mariadb-compose-db-1   | 2023-06-10 15:53:38 0 [Note] InnoDB: File './ibtmp1' size is now 12.000MiB.
docker-django-mariadb-compose-db-1   | 2023-06-10 15:53:38 0 [Note] InnoDB: log sequence number 47030; transaction id 16
docker-django-mariadb-compose-db-1   | 2023-06-10 15:53:38 0 [Note] InnoDB: Loading buffer pool(s) from /var/lib/mysql/ib_buffer_pool
docker-django-mariadb-compose-db-1   | 2023-06-10 15:53:38 0 [Note] Plugin 'FEEDBACK' is disabled.
docker-django-mariadb-compose-db-1   | 2023-06-10 15:53:38 0 [Warning] You need to use --log-bin to make --expire-logs-days or --binlog-expire-logs-seconds work.
docker-django-mariadb-compose-db-1   | 2023-06-10 15:53:38 0 [Note] Server socket created on IP: '0.0.0.0'.
docker-django-mariadb-compose-db-1   | 2023-06-10 15:53:38 0 [Note] Server socket created on IP: '::'.
docker-django-mariadb-compose-db-1   | 2023-06-10 15:53:38 0 [Note] InnoDB: Buffer pool(s) load completed at 230610 15:53:38
docker-django-mariadb-compose-db-1   | 2023-06-10 15:53:38 0 [Note] mariadbd: ready for connections.
docker-django-mariadb-compose-db-1   | Version: '10.11.3-MariaDB-1:10.11.3+maria~ubu2204'  socket: '/run/mysqld/mysqld.sock'  port: 3306  mariadb.org binary distribution
docker-django-mariadb-compose-web-1  | Watching for file changes with StatReloader
docker-django-mariadb-compose-web-1  | Performing system checks...
docker-django-mariadb-compose-web-1  | 
docker-django-mariadb-compose-web-1  | System check identified no issues (0 silenced).
docker-django-mariadb-compose-web-1  | 
docker-django-mariadb-compose-web-1  | You have 18 unapplied migration(s). Your project may not work properly until you apply the migrations for app(s): admin, auth, contenttypes, sessions.
docker-django-mariadb-compose-web-1  | Run 'python manage.py migrate' to apply them.
docker-django-mariadb-compose-web-1  | June 10, 2023 - 15:53:39
docker-django-mariadb-compose-web-1  | Django version 4.2.2, using settings 'blog.settings'
docker-django-mariadb-compose-web-1  | Starting development server at http://0.0.0.0:8000/
docker-django-mariadb-compose-web-1  | Quit the server with CONTROL-C.
docker-django-mariadb-compose-web-1  | 
docker-django-mariadb-compose-web-1  | [10/Jun/2023 15:53:59] "GET / HTTP/1.1" 200 10664
```